### PR TITLE
Integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,23 @@ services:
   - redis-server
 
 env:
-  - TRAVIS_NODE_VERSION="5.0.0"
+  global:
+    - TRAVIS_NODE_VERSION="5.0.0"
+    - ONAPP_CLOUDNET_ROLE=2
+    # Encrypted ENV vars to connect to an OnApp CP to run integration tests
+    - secure: "cQ8NWWSfeP61bAePpI9X5ZnkANb4F8KH21/xPFVXmp5MuWT5RQJpGdJRzj4ZyogCKcIcUN17gpkRjcUKrFl8cFIMqOg6LvWpXXG8N/7QEJ3Fs88oOrmrparBkfydSohPY7jR7CdmA6G0/Of+O8+HO3pk7WEzCuuspduhtqTHpY0rOUIPxyNnJwcjENe7dTUwKiwIHkp2LZrTwzF0ZEMnQvVVerR4cld4rf5irSLnuGAnfpT729AAU17T0P7hz+1QEw0gT24E+lhkjGPIaS83QK+PQtRhHsRk+Xi2TsxCsRPXpGzj1mMa6ARG2Hmh/2Km6FGpg0n9koC9+eAvZKbLSBHAMspTWjehhrPP3vOpf6nWiXbHESG67i+BHmiAJ5II7BEknJi2VvooWHAbrzaUbCqvLPk2OrposAkpJgUTaLXVFxH3i8wqG/B41E0CCCMfWbLop1E1a0OLpfBEkr9YNUTUR89hgN9MosORWQv5peqkVOytfcdJo77BiMFtJnaOgtEdI7F9M5Sz0NHxuWaXj9+UiRLtuHwzuiuppuCSMssmNl91gHMD9Vd5ABl2GW9CNOnphUT2ijp01/OcEgqehE4I31bPT6hnzHviCJo42RARF8WD1y7M/dNc7qrwc4drEBIHby3RgM/j3UBwoa+Q7jLwHWdys/jeriTC8ko1+CI="
+    - secure: "YsIeV9a7d8Lj+YGqL5vBZ54YGYfXuLyJy0jIk8WL5th9P9tH27LEMjjDPt/yN18LR9lXmXwJqiLxla6AeKpSImDKChvs9I4b1r5GpCe3b4zoxsgcSJ4yXiFQXh5EkK52dFlJcuvzFzQEa8yWcANdJB67UgNcSAt67gUXVxwNIkv2wH2jY2jfjMuWiTaYTfbWRFpHqWy7++hW77GUnYFAF34bAnSgx6fB5sxEh4LOw0SR7+Ed54+HXBBt8oFLy9dO0rr1K/rBhCTG1FgvoYA+H3nvIIdKxsduLE4KJkFkoG9P8koiedRFFiZqP6I4/XbULgMBSieHI1mQTxUfRpaNQnJDbA/c8DnuaX1yHViYduMz6YnVK8oZ1GzkVFkU9dWZYVjBaBiSDEjj7AewZB6hwTRoQctRV/wYwkORI8wGL8n8eRXDNHE8Gb4kzzpdTqH13+a0W3MAlLajWb5r5R5D+ZlmQuMoRmTHPZtzMjb3WR02gSc/EwCllb7a4hZLG351WC0zTlCRqOl4XRThmo+mviURxV+z0/6xXd5yngpbFe0HXFQ15w51PdvfEXao5bAwa5+1Zf2QyB8kybz9Y9rPhrpEkcli3Up5SlVCpDLUSn2Wl0XG85skecPoF0xXdP2471M0QDDONAkqGJFnbuirzI0iIxCVzjmJqxKVbvb0Nlw="
+    - secure: "De2CuNyujjBoJiAUpHEg0danvgP9U50YuvCK5a3ipuZqRNBl6ohQJ4h/BOsIrEtZsFNPxFLW4JDYEHGrGb3nbXcdKiKF8KUuOzU6KAtVff3oTkLNsx4IYNhRccLbxGD6Lh8vTV4oHs30/b+LT7rrFzcFJNgCOfswiN6Gw8US0cPrOyo3ZHtj9Uz/iOEKFG9etAzyxtC94q6o5QGVrjgzjMvSynPTCMmQSHTDKukcSxqUB3R22DKp/9ZwLsvWbtgn0xNUAQlJA733adm00D3iie5Tr6d6ctmnByaBc+mG3ziKiDlgtrox6q4vQTt2ds3NJ98HAK58sZQRbGHLA1TmNCcyDjNUGvQw4P2XgVHGrJSMUUeUBBVJg46PCqh+bk5TgOZC9xLfo9yW2CdRY40lXBuMG6OZRLLyQ+9Uq54nj3vNuVlOTFYKSTxVJUxtBH/St4ZXTJ5pQjRPWzxSYOflr0U3vjppHOgnTJ4duefKko635ffQpaFVz7cUUfCnqtTPBjvGB45S83FvMGHLvJ/Q7ZOorTSFfCa2e21noIutLdLwf6z2abi1EC3mj2j2nh0HTftBXxX4VyLXjctHfNFg5ey2UvnvE98GVsD4o3lSvRN0MYOhwe4YsPbUqQi78WUctec1yDxUFPl+7s7Lha5J7jyt4M1VBJdLioPQ5R0y51o="
+
+
+
+before_install:
+  # Make sure we're using phantomjs v2 and not the v1.9.8 that is currently default on Travis
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
+  - phantomjs --version
 
 install:
   # Install a newer version of node than Travis has, in order to run jsdom
@@ -23,7 +39,7 @@ install:
 
 script:
   # API tests
-  - bundle exec rspec spec
+  - bundle exec rspec spec/specs
   # Admin tests
   - cd admin && bundle exec rspec spec && cd ..
   # Frontend tests
@@ -32,7 +48,9 @@ script:
   - bundle exec rubocop
   # Coffeescript linter
   - npm run lint
+  # End to end integration tests. But skip if this is a Pull Request from an external fork
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then bundle exec rspec spec/integration; fi
 
 after_script:
-  # Update http://coveralls.io with the test coverage of both ruby and coffeescripts
-  - bundle exec rake coveralls:push
+  # Update http://coveralls.io with the test coverage of both ruby and coffeescript code
+  - cat ./coverage/ruby/lcov/cloudnetv2.lcov ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,11 @@ group :test do
   gem 'vcr'
   gem 'timecop'
   gem 'rubocop'
-  gem 'coveralls', require: false
+  gem 'capybara'
+  gem 'poltergeist'
+  gem 'net-ssh'
+  gem 'simplecov'
+  gem 'simplecov-lcov'
 end
 
 # Rails-specific gems are only used for the admin app, so relegate them to the bottom of this Gemfile.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     arbre (1.0.3)
       activesupport (>= 3.0.0)
     arel (6.0.3)
@@ -70,26 +70,16 @@ GEM
     bourbon (4.2.6)
       sass (~> 3.4)
       thor (~> 0.19)
-    bson (3.2.6)
+    bson (4.0.0)
     builder (3.2.2)
-    byebug (8.2.0)
-    celluloid (0.17.2)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.5)
-      timers (>= 4.1.1)
+    byebug (8.2.1)
+    capybara (2.5.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    cliver (0.3.2)
     coderay (1.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -100,19 +90,13 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.0)
     connection_pool (2.2.0)
-    coveralls (0.8.10)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.11.0)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (~> 1.6.0)
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (3.5.2)
+    devise (3.5.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -121,8 +105,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.0.2)
     easy_diff (0.0.6)
     equalizer (0.0.11)
@@ -138,7 +120,7 @@ GEM
     formtastic_i18n (0.4.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    grape (0.13.0)
+    grape (0.14.0)
       activesupport
       builder
       hashie (>= 2.1.0)
@@ -154,9 +136,9 @@ GEM
     grape-roar (0.3.0)
       grape
       roar (>= 1.0)
-    grape-swagger (0.10.2)
+    grape-swagger (0.10.4)
       grape (>= 0.8.0)
-      grape-entity
+      grape-entity (< 0.5.0)
     guard (2.13.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -179,9 +161,6 @@ GEM
       activesupport (>= 3.2, < 5)
     hashdiff (0.2.3)
     hashie (3.4.3)
-    hitimes (1.2.3)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     i18n (0.7.0)
     ice_nine (0.11.1)
     inherited_resources (1.6.0)
@@ -199,10 +178,10 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    listen (3.0.4)
+    listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    logglier (0.3.0)
+    logglier (0.4.1)
       multi_json (~> 1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -210,11 +189,11 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.6.2)
-    mini_portile (0.6.2)
-    minitest (5.8.2)
-    mongo (2.1.2)
-      bson (~> 3.0)
+    mime-types (2.99)
+    mini_portile2 (2.0.0)
+    minitest (5.8.3)
+    mongo (2.2.1)
+      bson (~> 4.0)
     mongoid (5.0.1)
       activemodel (~> 4.0)
       mongo (~> 2.1)
@@ -235,10 +214,10 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.2.0)
-    netrc (0.11.0)
-    newrelic_rpm (3.14.0.305)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    net-ssh (3.0.1)
+    newrelic_rpm (3.14.1.311)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -246,7 +225,12 @@ GEM
     orm_adapter (0.5.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
-    polyamorous (1.2.0)
+    poltergeist (1.8.1)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
+    polyamorous (1.3.0)
       activerecord (>= 3.0)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -300,24 +284,18 @@ GEM
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    redis (3.2.1)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
+    redis (3.2.2)
     representable (2.3.0)
       uber (~> 0.0.7)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
-    roar (1.0.3)
-      representable (>= 2.0.1, <= 3.0.0)
+    roar (1.0.4)
+      representable (>= 2.0.1, < 2.4.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.0)
+    rspec-core (3.4.1)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -333,7 +311,7 @@ GEM
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
-    rspec-support (3.4.0)
+    rspec-support (3.4.1)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -343,7 +321,7 @@ GEM
       tins (<= 1.6.0)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.4.20)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -353,19 +331,20 @@ GEM
     sentry-raven (0.15.2)
       faraday (>= 0.7.6)
     shellany (0.0.1)
-    sidekiq (3.5.3)
-      celluloid (~> 0.17.2)
+    sidekiq (4.0.1)
+      concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
-      redis-namespace (~> 1.5, >= 1.5.2)
     simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    simplecov-lcov (0.5.0)
     slop (3.6.0)
-    sprockets (3.4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
       actionpack (>= 3.0)
@@ -373,33 +352,31 @@ GEM
       sprockets (>= 2.8, < 4.0)
     symmetric-encryption (3.8.2)
       coercible (~> 1.0)
-    term-ansicolor (1.3.2)
-      tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
     timecop (0.8.0)
-    timers (4.1.1)
-      hitimes
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.1)
     vcr (3.0.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.3)
+    warden (1.2.4)
       rack (>= 1.0)
     webmock (1.22.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -407,7 +384,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   bcrypt
-  coveralls
+  capybara
   devise
   dotenv
   fabrication
@@ -423,7 +400,9 @@ DEPENDENCIES
   mongoid
   mongoid-history
   mongoid_paranoia
+  net-ssh
   newrelic_rpm
+  poltergeist
   pry
   pry-byebug
   puma
@@ -437,6 +416,8 @@ DEPENDENCIES
   rubocop
   sentry-raven
   sidekiq
+  simplecov
+  simplecov-lcov
   symmetric-encryption
   timecop
   vcr

--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,10 @@ require 'bundler'
 require 'rake'
 
 # Push latest coverage test results to http://coveralls.io
-require 'coveralls/rake/task'
-Coveralls::RakeTask.new
+if ENV['RACK_ENV'] == 'test'
+  require 'coveralls/rake/task'
+  Coveralls::RakeTask.new
+end
 
 ENV['RACK_ENV'] ||= 'development'
 

--- a/app/api.rb
+++ b/app/api.rb
@@ -1,4 +1,3 @@
-
 require 'app/routes/auth'
 require 'app/routes/datacentre'
 require 'app/routes/server'

--- a/app/models/server/server.rb
+++ b/app/models/server/server.rb
@@ -37,7 +37,7 @@ class Server
   field :bandwidth, type: Float, default: 0.0
 
   field :ip_address
-  field :root_password
+  field :initial_root_password
 
   validates_presence_of :user, :template, :name, :hostname
 
@@ -72,6 +72,7 @@ class Server
       cpus: cpus,
       cpu_shares: 100,
       primary_disk_size: disk_size - required_swap,
+      initial_root_password: initial_root_password,
       swap_disk_size: required_swap,
       template_id: template.id,
       required_virtual_machine_build: 1,
@@ -86,6 +87,7 @@ class Server
   end
 
   def create_onapp_server
+    self.initial_root_password = System.generate_onapp_password
     response = onapp.api(:post, virtual_machine: prepare_onapp_params)['virtual_machine']
     self.onapp_identifier = response['identifier']
     save!

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -26,4 +26,23 @@ class System
   rescue Mongoid::Errors::DocumentNotFound
     create key: key, value: value
   end
+
+  class << self
+    # OnApp passwords must conform to OnApp's requirements of 1 special char, 1 uppper, 1 lower and
+    # 1 number.
+    def generate_onapp_password(password_length = 12)
+      # Define the types of characters required by the OnApp API
+      symbols = '&()*%$!'.split ''
+      lower = ('a'..'z').to_a
+      upper = ('A'..'Z').to_a
+      numbers = (1..9).to_a
+      types = [symbols, lower, upper, numbers]
+      all = types.flatten
+      # Take 1 random character from each group to ensure we meet OnApp's requirements
+      required = types.map(&:sample)
+      # Fill the rest of the password with random samplings from the all groups
+      fill = (0...password_length - 4).map { all.sample }
+      (required + fill).shuffle.join
+    end
+  end
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -32,7 +32,9 @@ class Template
 
   class << self
     def find_an_ubuntu_template
-      Template.all.to_a.find { |t| t.os_distro =~ /ubuntu/ }
+      template = Template.all.to_a.find { |t| t.os_distro =~ /ubuntu/ && t.label =~ /14\.04/ }
+      fail "Couldn't find an Ubuntu 14.04 template" unless template.is_a? Template
+      template
     end
   end
 end

--- a/app/models/user/user.rb
+++ b/app/models/user/user.rb
@@ -83,20 +83,6 @@ class User
       user.worker.create_onapp_user_and_save
     end
 
-    # Create the non-privileged OnApp user role that all cloud.net users use to interact with OnApp
-    # NB. This should only need to be done when setting up cloud.net for the first time.
-    def create_onapp_role
-      OnappAPI.admin_connection.post(
-        :roles,
-        body: {
-          role: {
-            label: 'user',
-            permission_ids: Cloudnet::ONAPP_USER_PERMISSIONS
-          }
-        }
-      ).role.id
-    end
-
     # Check the incoming API request headers for a valid authentication credential
     def authourize(auth_header)
       type = auth_header.split[0].strip

--- a/app/models/user/user_creation.rb
+++ b/app/models/user/user_creation.rb
@@ -38,7 +38,7 @@ module UserCreation
       user: {
         login: username,
         email: "#{username}@cloud.net",
-        password: generate_onapp_password,
+        password: System.generate_onapp_password(PASSWORD_SIZE),
         role_ids: [Cloudnet.onapp_cloudnet_role]
       }
     }
@@ -52,23 +52,6 @@ module UserCreation
       response = OnappAPI.admin :post, '/users/validate_login', body: { login: username }
       return username if response['valid']
     end
-  end
-
-  # OnApp passwords must conform to OnApp's requirements of 1 special char, 1 uppper, 1 lower and
-  # 1 number.
-  def generate_onapp_password
-    # Define the types of characters required by the OnApp API
-    symbols = '&()*%$!'.split ''
-    lower = ('a'..'z').to_a
-    upper = ('A'..'Z').to_a
-    numbers = (1..9).to_a
-    types = [symbols, lower, upper, numbers]
-    all = types.flatten
-    # Take 1 random character from each group to ensure we meet OnApp's requirements
-    required = types.map(&:sample)
-    # Fill the rest of the password with random samplings from the all groups
-    fill = (0...PASSWORD_SIZE - 4).map { all.sample }
-    (required + fill).shuffle.join
   end
 
   # Generate a confirmation token for a URL that a user can click to confirm their account

--- a/app/representers/server.rb
+++ b/app/representers/server.rb
@@ -14,7 +14,7 @@ module ServerRepresenter
   property :cpus
   property :disk_size
   property :state
-  property :root_password
+  property :initial_root_password
   property :ip_address
   property :template, extend: TemplateRepresenter
   collection :transactions do

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,6 @@
+require_relative 'config/boot' unless ENV['RACK_ENV'] == 'test'
+
 require 'rack/cors'
-require_relative 'config/boot'
 
 use Rack::CommonLogger, Cloudnet.logger
 use Raven::Rack

--- a/config/setup/logging.rb
+++ b/config/setup/logging.rb
@@ -43,7 +43,8 @@ module Logging
     def choose_logger
       case Cloudnet.environment
       when 'test'
-        ::Logger.new '/dev/null'
+        FileUtils.mkdir_p "#{Cloudnet.root}/log"
+        ::Logger.new File.new "#{Cloudnet.root}/log/tests.log", 'w'
       when 'production', 'staging'
         Logglier.new ENV['LOGGLY_URI'], threaded: true
       else

--- a/frontend/app/scripts/lib/ajax.coffee
+++ b/frontend/app/scripts/lib/ajax.coffee
@@ -19,7 +19,7 @@ class AJAX
       # @originalRoute = m.route()
       Logger.error 'Unauthorised AJAX request', result.message.error
       m.route '/login'
-    Logger.error 'AJAX error', result.message.error
+    Logger.error 'AJAX error', JSON.stringify result.message.error
     result
 
   # Central wrapper around Mithril's request method

--- a/frontend/app/scripts/lib/api.coffee
+++ b/frontend/app/scripts/lib/api.coffee
@@ -8,7 +8,7 @@ class API
   @base = if document.location.hostname.indexOf('localhost') >= 0
     'http://api.localhost:9393'
   else
-    "http://#{document.location.hostname}".replace 'www.', 'api.'
+    "http://#{document.location.hostname}:#{document.location.port}".replace 'www.', 'api.'
 
   constructor: ->
     @ajax = new AJAX

--- a/frontend/app/scripts/lib/helpers.coffee
+++ b/frontend/app/scripts/lib/helpers.coffee
@@ -1,8 +1,21 @@
-module.exports.extend = (object, properties) ->
-  for key, val of properties
-    object[key] = val
-  object
+module.exports = {
+  extend: (object, properties) ->
+    for key, val of properties
+      object[key] = val
+    object
 
-module.exports.formatTime = (dateTime) ->
-  dateTime = new Date(dateTime)
-  dateTime.toUTCString()
+  formatTime: (dateTime) ->
+    dateTime = new Date(dateTime)
+    dateTime.toUTCString()
+
+  toSlug: (str) ->
+    str = str.replace(/^\s+|\s+$/g, '').toLowerCase() # trim and force lowercase
+    from = 'àáäâèéëêìíïîòóöôùúüûñç·/_,:;'
+    to   = 'aaaaeeeeiiiioooouuuunc------'
+    for i in [i..from.length]
+      str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+    # remove accents, swap ñ for n, etc
+    str = str.replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-')
+    # remove invalid chars, collapse whitespace and replace by -, collapse dashes
+    return str # unnecessary line, but for clarity
+}

--- a/frontend/app/scripts/main.coffee
+++ b/frontend/app/scripts/main.coffee
@@ -1,6 +1,8 @@
 global.env ||= 'DEV' if document.location.hostname == 'localhost'
 
-unless global.env == 'DEV' || global.env == 'TEST'
+integration_tests = true if document.location.hostname == 'www.vcap.me'
+
+unless global.env == 'DEV' || global.env == 'TEST' || integration_tests
   # Report errors to app.getsentry.com
   Raven = require 'raven-js'
   # A browserify transform will add the DSN URI from the ENV
@@ -15,7 +17,7 @@ Logger.level = Logger.DEBUG if global.env == 'DEV'
 api = require 'lib/api'
 
 
-# Convert something like { a: {b: 'value'}} to {'a/b': 'value'}
+# Convert something like {a: {b: 'value'}} to {'a/b': 'value'}
 # Provides compatibility with the `require-globify` syntax
 deepHashToSlashes = (hash, newHash, newKeyParts) ->
   rootLevel = typeof newHash is 'undefined'
@@ -33,7 +35,7 @@ deepHashToSlashes = (hash, newHash, newKeyParts) ->
 
 # Preload all controllers and views and save them to a hash for referencing later.
 # We need to use different require modules depending on the environment. `require-globify` doesn't
-# work without browserify (browserify isn't run by jasmine-node), so we use `require-dir` instead.
+# work without browserify (browserify isn't run by mocha), so we use `require-dir` instead.
 # And `require-dir` doesn't work in the browser (because of differences in commonjs, namely the
 # missing require.resolve function), so we use `require-globify` instead.
 if global.env == 'TEST'

--- a/frontend/app/scripts/views/_partials/key_value_widget.coffee
+++ b/frontend/app/scripts/views/_partials/key_value_widget.coffee
@@ -1,9 +1,11 @@
 m = require 'mithril'
+helpers = require 'lib/helpers'
 
 module.exports = (hash) ->
   for key, value of hash
+    selectorForValue = helpers.toSlug "keyvalues-#{key}-value"
     [
       m '.row',
         m 'strong.small-2.columns', key
-        m '.small-6.columns.end', value
+        m ".small-6.columns.end.#{selectorForValue}", value
     ]

--- a/frontend/app/scripts/views/servers.coffee
+++ b/frontend/app/scripts/views/servers.coffee
@@ -18,7 +18,7 @@ module.exports = (controller) ->
         'CPUs': server.cpus,
         'Disk': "#{server.disk_size}GB",
         'IP Address': server.ip_address,
-        'Root Password': server.root_password
+        'Root Password': server.initial_root_password
       }
 
     m 'h2', 'Usage'

--- a/frontend/spec/coverage_helper.coffee
+++ b/frontend/spec/coverage_helper.coffee
@@ -1,4 +1,4 @@
-# The *only* reasons this file exists is to pass '/vendor' to the excludes array.
+# The *only* reasons this file exists is to pass custom paths to the excludes array.
 # And the only reason we need that is to stop coverage reporting failing on Travis.
 # So a bit of hack. Surely there is a smaller and simpler solution.
 
@@ -17,7 +17,7 @@ initAll = if (_ref = process.env.COFFEECOV_INIT_ALL) != null then _ref == 'true'
 coffeeCoverage.register({
   instrumentor: 'istanbul',
   basePath: process.cwd(),
-  exclude: ['/test', '/node_modules', '/.git', '/vendor'],
+  exclude: ['/frontend/spec', '/node_modules', '/.git', '/vendor', '/admin'],
   coverageVar: coverageVar,
   writeOnExit: writeOnExit,
   initAll: initAll

--- a/lib/onapp_api.rb
+++ b/lib/onapp_api.rb
@@ -66,6 +66,8 @@ module OnappAPI
         request.url path
         add_params request, params if params
       end
+    rescue Faraday::ClientError => exception
+      raise exception, exception.response
     end
 
     def add_params(request, params)
@@ -80,6 +82,7 @@ module OnappAPI
     def get_connection(user)
       ssl_verify = Cloudnet.environment == 'production'
       Faraday.new(url: API_URI, ssl: { verify: ssl_verify }) do |faraday|
+        faraday.use Faraday::Response::RaiseError
         faraday.adapter Faraday.default_adapter
         faraday.basic_auth(*credentials(user))
       end

--- a/lib/transactions_daemon/consumer_methods.rb
+++ b/lib/transactions_daemon/consumer_methods.rb
@@ -24,7 +24,6 @@ module Transactions
       @server.state = :building
       @server.built = false
       @server.locked = true
-      @server.root_password = vm['remote_access_password']
       # Is this the best place to get the IP address?
       @server.ip_address = vm['ip_addresses'][0]['ip_address']['address']
       @server.save!

--- a/lib/transactions_daemon/transactions_sync.rb
+++ b/lib/transactions_daemon/transactions_sync.rb
@@ -34,6 +34,7 @@ module Transactions
     end
 
     def run
+      logger.info 'Starting Transactions Daemon'
       # This is a daemon, so loop forever
       loop { fetch_batch }
     end

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "coffeeify": "~1.1.0",
     "coffeelint": "^1.10.1",
     "connect-history-api-fallback": "^1.1.0",
+    "coveralls": "^2.11.6",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-changed": "^1.2.1",

--- a/spec/fixtures/cassettes/Server/OnApp_API_interaction/should_create_and_destroy_an_onapp_server_along_with_a_local_cloud_net_server.yml
+++ b/spec/fixtures/cassettes/Server/OnApp_API_interaction/should_create_and_destroy_an_onapp_server_along_with_a_local_cloud_net_server.yml
@@ -6,15 +6,23 @@ http_interactions:
       extract_domain ENV["ONAPP_URI"] %>/users/validate_login.json
     body:
       encoding: UTF-8
-      string: login=rspec-test-_9c837d
-    headers: {}
+      string: '{"login":"rspec-test-_5525c9"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 26 Oct 2015 17:17:30 GMT
+      - Mon, 14 Dec 2015 14:27:23 GMT
       Server:
       - Apache/2.2.15 (CentOS)
       X-Ua-Compatible:
@@ -24,15 +32,15 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c953336e01a43d9cba14bb03c8a1ce03
+      - 92c1d8217fadb3a61561f12178dba551
       X-Runtime:
-      - '0.216988'
+      - '1.150577'
       X-Rack-Cache:
       - invalidate, pass
       X-Powered-By:
       - Phusion Passenger 4.0.35
       Set-Cookie:
-      - _session_id=28bf58b75c25135d6dfddfd54ddaf7ef; path=/; HttpOnly
+      - _session_id=219b3c269a1df575e64e00f32c94ba07; path=/; HttpOnly
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Status:
@@ -47,44 +55,52 @@ http_interactions:
       encoding: UTF-8
       string: '{"valid":true,"message":"Username is available"}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 17:17:16 GMT
+  recorded_at: Mon, 14 Dec 2015 14:26:50 GMT
 - request:
     method: post
     uri: https://<%= ENV["ONAPP_USER"] %>:<%= CGI.escape ENV["ONAPP_PASS"] %>@<%=
       extract_domain ENV["ONAPP_URI"] %>/users.json
     body:
       encoding: UTF-8
-      string: user[login]=rspec-test-_9c837d&user[email]=rspec-test-_9c837d%40cloud.net&user[password]=Ln%2AzYwnw%2AI5Lk8Ru&user[role_ids][]=2
-    headers: {}
+      string: '{"user":{"login":"rspec-test-_5525c9","email":"rspec-test-_5525c9@cloud.net","password":"%GkO$!SU2w%OsqEx","role_ids":["2"]}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
       Date:
-      - Mon, 26 Oct 2015 17:17:32 GMT
+      - Mon, 14 Dec 2015 14:27:25 GMT
       Server:
       - Apache/2.2.15 (CentOS)
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"84ca0201c6682fa05452e4d5243f52ee"'
+      - '"1535926607f53e5d27e0d5d3254a4f67"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 81d855607cf5ab8d69dcebff2311cfc7
+      - 0730bfbd28faf9ff4d6e9f523f6d9fec
       X-Runtime:
-      - '1.074317'
+      - '3.920858'
       X-Rack-Cache:
       - invalidate, pass
       X-Powered-By:
       - Phusion Passenger 4.0.35
       Set-Cookie:
-      - _session_id=cd3f7a7e6a8eef22f3e69e6b0ae7db09; path=/; HttpOnly
+      - _session_id=bd09707ad4b676b20f3c5b1e850f3562; path=/; HttpOnly
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Location:
-      - https://<%= extract_domain ENV["ONAPP_URI"] %>/users/403
+      - https://<%= extract_domain ENV["ONAPP_URI"] %>/users/560
       Status:
       - 201 Created
       Connection:
@@ -95,7 +111,7 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: UTF-8
-      string: '{"user":{"activated_at":"2015-10-26T17:17:33+00:00","avatar":null,"billing_plan_id":1,"cdn_account_status":"ACTIVE","cdn_status":"INACTIVE","created_at":"2015-10-26T17:17:32+00:00","deleted_at":null,"email":"rspec-test-_9c837d@cloud.net","firewall_id":null,"first_name":"","group_id":null,"id":403,"identifier":"kj3bo1h06tn000","image_template_group_id":null,"infoboxes":{"display_infoboxes":true,"hidden_infoboxes":[]},"last_name":"","locale":"en","login":"rspec-test-_9c837d","password_changed_at":"2015-10-26T17:17:32+00:00","status":"active","supplied":false,"suspend_at":null,"system_theme":null,"time_zone":null,"total_amount":0.0,"updated_at":"2015-10-26T17:17:33+00:00","use_gravatar":null,"user_group_id":null,"outstanding_amount":"0.0","payment_amount":"0.0","roles":[{"role":{"created_at":"2015-03-12T13:24:37+00:00","id":2,"identifier":"user","label":"User","updated_at":"2015-03-12T13:24:37+00:00","permissions":[{"permission":{"created_at":"2015-03-12T13:24:37+00:00","id":7,"identifier":"activity_logs.read.own","label":"See
+      string: '{"user":{"activated_at":"2015-12-14T14:27:27+00:00","avatar":null,"billing_plan_id":1,"cdn_account_status":"ACTIVE","cdn_status":"INACTIVE","created_at":"2015-12-14T14:27:27+00:00","deleted_at":null,"email":"rspec-test-_5525c9@cloud.net","firewall_id":null,"first_name":"","group_id":null,"id":560,"identifier":"np3pq8sh3ywvcd","image_template_group_id":null,"infoboxes":{"display_infoboxes":true,"hidden_infoboxes":[]},"last_name":"","locale":"en","login":"rspec-test-_5525c9","password_changed_at":"2015-12-14T14:27:27+00:00","status":"active","supplied":false,"suspend_at":null,"system_theme":null,"time_zone":null,"total_amount":0.0,"updated_at":"2015-12-14T14:27:27+00:00","use_gravatar":null,"user_group_id":null,"outstanding_amount":"0.0","payment_amount":"0.0","roles":[{"role":{"created_at":"2015-03-12T13:24:37+00:00","id":2,"identifier":"user","label":"User","updated_at":"2015-11-04T12:41:26+00:00","permissions":[{"permission":{"created_at":"2015-03-12T13:24:37+00:00","id":7,"identifier":"activity_logs.read.own","label":"See
         details of own activity log","updated_at":"2015-03-12T13:24:37+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:38+00:00","id":32,"identifier":"backups.convert.own","label":"Convert
         own backup to template","updated_at":"2015-03-12T13:24:38+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:38+00:00","id":34,"identifier":"backups.create.own","label":"Create
         an own backup","updated_at":"2015-03-12T13:24:38+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:38+00:00","id":36,"identifier":"backups.delete.own","label":"Destroy
@@ -189,8 +205,7 @@ http_interactions:
         publications for all virtual servers","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":528,"identifier":"virtual_machines.migrate.own","label":"Migrate
         own virtual machine","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":530,"identifier":"virtual_machines.power.own","label":"Any
         power action on own virtual machines","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":532,"identifier":"virtual_machines.read.own","label":"See
-        own virtual machines","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":533,"identifier":"virtual_machines.read_root_password","label":"Read
-        Virtual Machine''s root password","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":537,"identifier":"virtual_machines.rebuild_network.own","label":"Rebuild
+        own virtual machines","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":537,"identifier":"virtual_machines.rebuild_network.own","label":"Rebuild
         Network to own virtual machine","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":539,"identifier":"virtual_machines.recipe_manage.own","label":"Manage
         recipes joins for own virtual servers","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":541,"identifier":"virtual_machines.reset_root_password.own","label":"Reset
         root password to own virtual machine","updated_at":"2015-03-12T13:24:40+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":547,"identifier":"virtual_machines.update.own","label":"Update
@@ -200,9 +215,10 @@ http_interactions:
         own CDN SSL Certificates","updated_at":"2015-06-24T14:37:54+00:00"}},{"permission":{"created_at":"2015-06-24T14:37:54+00:00","id":574,"identifier":"cdn_ssl_certificates.read.own","label":"See
         own CDN SSL Certificates","updated_at":"2015-06-24T14:37:54+00:00"}},{"permission":{"created_at":"2015-06-24T14:37:54+00:00","id":575,"identifier":"cdn_ssl_certificates.update.own","label":"Update
         own CDN SSL Certificates","updated_at":"2015-06-24T14:37:54+00:00"}},{"permission":{"created_at":"2015-09-10T18:45:32+00:00","id":636,"identifier":"virtual_machines.select_resources_manually_on_creation","label":"Select
-        resources manually on Virtual Server creation","updated_at":"2015-09-10T18:45:32+00:00"}}]}}],"used_cpus":0,"used_memory":0,"used_cpu_shares":0,"used_disk_size":0,"used_ip_addresses":[],"memory_available":94077,"disk_space_available":1515,"additional_fields":[]}}'
+        resources manually on Virtual Server creation","updated_at":"2015-09-10T18:45:32+00:00"}},{"permission":{"created_at":"2015-03-12T13:24:40+00:00","id":534,"identifier":"virtual_machines.read_root_password.own","label":"Read
+        own Virtual Machine''s root password","updated_at":"2015-03-12T13:24:40+00:00"}}]}}],"used_cpus":0,"used_memory":0,"used_cpu_shares":0,"used_disk_size":0,"used_ip_addresses":[],"memory_available":79251,"disk_space_available":1330,"additional_fields":[]}}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 17:17:19 GMT
+  recorded_at: Mon, 14 Dec 2015 14:26:55 GMT
 - request:
     method: get
     uri: https://<%= ENV["ONAPP_USER"] %>:<%= CGI.escape ENV["ONAPP_PASS"] %>@<%=
@@ -210,32 +226,38 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 26 Oct 2015 17:17:39 GMT
+      - Mon, 14 Dec 2015 14:27:30 GMT
       Server:
       - Apache/2.2.15 (CentOS)
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"8bddd14bb2206ca6397766848447322e"'
+      - '"0041236604a94397a24c55dfe89119ad"'
       Cache-Control:
       - must-revalidate, private, max-age=0
       X-Request-Id:
-      - 13067e67a0be2e5cbca7c32d1b29c424
+      - 8032e6d8627c1cce27d5668304954033
       X-Runtime:
-      - '0.392041'
+      - '1.579691'
       X-Rack-Cache:
       - miss
       X-Powered-By:
       - Phusion Passenger 4.0.35
       Set-Cookie:
-      - _session_id=9b5ef336ec50fdd438eb2476f1aba743; path=/; HttpOnly
+      - _session_id=998bcbe69b75c99a8143feb0a452f6ec; path=/; HttpOnly
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Status:
@@ -262,7 +284,7 @@ http_interactions:
         6.5 x64","created_at":"2015-06-24T15:33:51+00:00","updated_at":"2015-06-24T15:33:51+00:00","version":"1.4","file_name":null,"operating_system":"linux","operating_system_distro":"rhel","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":true,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,kvm_virtio,remote","min_memory_size":384,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:2","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":67,"template_id":30,"image_template_group_id":8,"price":"0.0","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","image_template":{"id":30,"label":"CentOS
         6.5 x86","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","version":"1.0","file_name":null,"operating_system":"linux","operating_system_distro":"rhel","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":false,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,kvm_virtio,remote","min_memory_size":384,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:20","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":87,"template_id":51,"image_template_group_id":8,"price":"0.0","created_at":"2015-10-14T19:00:13+00:00","updated_at":"2015-10-14T19:00:13+00:00","image_template":{"id":51,"label":"CentOS
         6.7 x64 McMyAdmin2","created_at":"2015-10-14T19:00:12+00:00","updated_at":"2015-10-14T19:00:12+00:00","version":"1.0","file_name":null,"operating_system":"linux","operating_system_distro":"rhel","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":true,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,kvm_virtio,remote","min_memory_size":384,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:69","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":86,"template_id":49,"image_template_group_id":8,"price":"0.0","created_at":"2015-09-09T19:00:08+00:00","updated_at":"2015-09-09T19:00:08+00:00","image_template":{"id":49,"label":"CentOS
-        6.7 x64 OnApp 4.1.0","created_at":"2015-09-09T19:00:08+00:00","updated_at":"2015-10-03T04:00:10+00:00","version":"1.2","file_name":null,"operating_system":"linux","operating_system_distro":"rhel","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":true,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,kvm_virtio,remote","min_memory_size":384,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:63","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":63,"template_id":26,"image_template_group_id":8,"price":"0.0","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","image_template":{"id":26,"label":"CentOS
+        6.7 x64 OnApp 4.1.0","created_at":"2015-09-09T19:00:08+00:00","updated_at":"2015-11-05T17:00:15+00:00","version":"1.3","file_name":null,"operating_system":"linux","operating_system_distro":"rhel","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":true,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,kvm_virtio,remote","min_memory_size":384,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:63","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":63,"template_id":26,"image_template_group_id":8,"price":"0.0","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","image_template":{"id":26,"label":"CentOS
         7.0 x64 ","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","version":"1.6","file_name":null,"operating_system":"linux","operating_system_distro":"rhel","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":true,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,kvm_virtio,remote","min_memory_size":384,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:17","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":66,"template_id":29,"image_template_group_id":8,"price":"0.0","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","image_template":{"id":29,"label":"Debian
         6.0 x64 LAMP","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","version":"1.7","file_name":null,"operating_system":"linux","operating_system_distro":"ubuntu","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":false,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,remote","min_memory_size":128,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:22","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":77,"template_id":40,"image_template_group_id":8,"price":"0.0","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","image_template":{"id":40,"label":"Debian
         7.0 x64","created_at":"2015-06-24T15:33:52+00:00","updated_at":"2015-06-24T15:33:52+00:00","version":"1.10","file_name":null,"operating_system":"linux","operating_system_distro":"ubuntu","allowed_swap":true,"state":"active","checksum":null,"allow_resize_without_reboot":true,"min_disk_size":5,"user_id":null,"template_size":0,"allowed_hot_migrate":false,"operating_system_arch":null,"operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm,kvm_virtio,remote","min_memory_size":128,"disk_target_device":null,"cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":"template:vm:onapp-resource:compute:onapp-pJrxhNrW3xxVBcnfJyEv5AISjPg:3","manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}},{"id":55,"template_id":18,"image_template_group_id":8,"price":"0.0","created_at":"2015-06-24T15:33:51+00:00","updated_at":"2015-06-24T15:33:51+00:00","image_template":{"id":18,"label":"Debian
@@ -312,44 +334,52 @@ http_interactions:
         Balancer Virtual Appliance","created_at":"2015-03-12T14:26:02+00:00","updated_at":"2015-09-12T22:13:21+00:00","version":"1.9","file_name":"centos-5.3-lbva_6.11-x64-1.9.tar.gz","operating_system":"linux","operating_system_distro":"lbva","allowed_swap":true,"state":"active","checksum":"3a5bc442a326a7d575a724b6ca93e83e","allow_resize_without_reboot":true,"min_disk_size":5,"user_id":null,"template_size":762648,"allowed_hot_migrate":true,"operating_system_arch":"x64","operating_system_edition":null,"operating_system_tail":null,"parent_template_id":null,"virtualization":"xen,kvm","min_memory_size":512,"disk_target_device":"---\nxen:
         sda\nkvm: hd\n","cdn":false,"backup_server_id":null,"ext4":false,"smart_server":false,"baremetal_server":false,"initial_password":null,"initial_username":null,"remote_id":null,"manager_id":null,"resize_without_reboot_policy":{},"type":"ImageTemplate","application_server":false}}]}]'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 17:17:26 GMT
+  recorded_at: Mon, 14 Dec 2015 14:26:57 GMT
 - request:
     method: post
-    uri: https://rspec-test-_9c837d:Ln%2AzYwnw%2AI5Lk8Ru@<%= extract_domain ENV["ONAPP_URI"]
-      %>/virtual_machines.json?virtual_machine%5Bcpu_shares%5D=100&virtual_machine%5Bcpus%5D=1&virtual_machine%5Bhostname%5D=rspec-test-user-s-server-1&virtual_machine%5Bhypervisor_group_id%5D=7&virtual_machine%5Blabel%5D=Rspec%20Test%20User%27s%20Server%201&virtual_machine%5Bmemory%5D=512.0&virtual_machine%5Bnote%5D=Created%20with%20Cloud.net&virtual_machine%5Bprimary_disk_size%5D=19.0&virtual_machine%5Brequired_ip_address_assignment%5D=1&virtual_machine%5Brequired_virtual_machine_build%5D=1&virtual_machine%5Brequired_virtual_machine_startup%5D=1&virtual_machine%5Bswap_disk_size%5D=1.0&virtual_machine%5Btemplate_id%5D=29
+    uri: https://rspec-test-_5525c9:%25GkO%24%21SU2w%25OsqEx@<%= extract_domain ENV["ONAPP_URI"]
+      %>/virtual_machines.json?virtual_machine%5Bcpu_shares%5D=100&virtual_machine%5Bcpus%5D=1&virtual_machine%5Bhostname%5D=rspec-test-user-s-server-1&virtual_machine%5Bhypervisor_group_id%5D=7&virtual_machine%5Binitial_root_password%5D=ABC123abc!%25$&virtual_machine%5Blabel%5D=Rspec%20Test%20User%27s%20Server%201&virtual_machine%5Bmemory%5D=512.0&virtual_machine%5Bnote%5D=Created%20with%20Cloud.net&virtual_machine%5Bprimary_disk_size%5D=19.0&virtual_machine%5Brequired_ip_address_assignment%5D=1&virtual_machine%5Brequired_virtual_machine_build%5D=1&virtual_machine%5Brequired_virtual_machine_startup%5D=1&virtual_machine%5Bswap_disk_size%5D=1.0&virtual_machine%5Btemplate_id%5D=31
     body:
       encoding: UTF-8
       string: ''
-    headers: {}
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
       Date:
-      - Mon, 26 Oct 2015 17:17:40 GMT
+      - Mon, 14 Dec 2015 14:27:33 GMT
       Server:
       - Apache/2.2.15 (CentOS)
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       Etag:
-      - '"18cf7289e75fd7605d53c9618c32d690"'
+      - '"8409f53ce005ba37ebec3b5cdce2a0e8"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - eb1e89d818b2a0b581de54da16b3d442
+      - 76d2df54504d94b5ffcf87860100ba26
       X-Runtime:
-      - '3.651458'
+      - '4.479736'
       X-Rack-Cache:
       - invalidate, pass
       X-Powered-By:
       - Phusion Passenger 4.0.35
       Set-Cookie:
-      - _session_id=01f1dbbc01f3829c7523ad4fbd79c42c; path=/; HttpOnly
+      - _session_id=fdb8fad93259fb28746c9f7f38d75bfb; path=/; HttpOnly
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Location:
-      - https://<%= extract_domain ENV["ONAPP_URI"] %>/virtual_machines/mtcpy07758diww
+      - https://<%= extract_domain ENV["ONAPP_URI"] %>/virtual_machines/vdf9kraadsrk1b
       Status:
       - 201 Created
       Connection:
@@ -361,27 +391,33 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"virtual_machine":{"add_to_marketplace":null,"<%= ENV["ONAPP_USER"]
-        %>_note":null,"allowed_hot_migrate":false,"allowed_swap":true,"booted":false,"built":false,"cores_per_socket":0,"cpu_shares":100,"cpu_sockets":null,"cpu_threads":null,"cpu_units":null,"cpus":1,"created_at":"2015-10-26T17:17:44+00:00","customer_network_id":null,"deleted_at":null,"edge_server_type":null,"enable_autoscale":false,"enable_monitis":false,"firewall_notrack":false,"hostname":"rspec-test-user-s-server-1","hot_add_cpu":null,"hot_add_memory":null,"hypervisor_id":2,"id":114,"identifier":"mtcpy07758diww","initial_root_password_encrypted":false,"instance_type_id":null,"iso_id":null,"label":"Rspec
+        %>_note":null,"allowed_hot_migrate":false,"allowed_swap":true,"booted":false,"built":false,"cores_per_socket":0,"cpu_shares":100,"cpu_sockets":null,"cpu_threads":null,"cpu_units":null,"cpus":1,"created_at":"2015-12-14T14:27:37+00:00","customer_network_id":null,"deleted_at":null,"edge_server_type":null,"enable_autoscale":false,"enable_monitis":false,"firewall_notrack":false,"hostname":"rspec-test-user-s-server-1","hot_add_cpu":null,"hot_add_memory":null,"hypervisor_id":2,"id":331,"identifier":"vdf9kraadsrk1b","initial_root_password_encrypted":false,"instance_type_id":null,"iso_id":null,"label":"Rspec
         Test User''s Server 1","local_remote_access_ip_address":null,"local_remote_access_port":null,"locked":false,"memory":512,"min_disk_size":5,"note":"Created
-        with Cloud.net","operating_system":"linux","operating_system_distro":"ubuntu","preferred_hvs":[],"recovery_mode":null,"remote_access_password":null,"service_password":null,"state":"new","storage_server_type":null,"strict_virtual_machine_id":null,"suspended":false,"template_id":29,"template_label":"Debian
-        6.0 x64 LAMP","time_zone":null,"updated_at":"2015-10-26T17:17:44+00:00","user_id":403,"vip":null,"xen_id":null,"ip_addresses":[],"monthly_bandwidth_used":"0","total_disk_size":0,"price_per_hour":"0.0","price_per_hour_powered_off":"0.0","support_incremental_backups":true,"cpu_priority":100}}'
+        with Cloud.net","operating_system":"linux","operating_system_distro":"ubuntu","preferred_hvs":[],"recovery_mode":null,"remote_access_password":null,"service_password":null,"state":"new","storage_server_type":null,"strict_virtual_machine_id":null,"suspended":false,"template_id":31,"template_label":"Ubuntu
+        14.04 x64","time_zone":null,"updated_at":"2015-12-14T14:27:37+00:00","user_id":560,"vip":null,"xen_id":null,"ip_addresses":[],"monthly_bandwidth_used":"0","total_disk_size":0,"price_per_hour":"0.0","price_per_hour_powered_off":"0.0","support_incremental_backups":true,"cpu_priority":100}}'
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 17:17:30 GMT
+  recorded_at: Mon, 14 Dec 2015 14:27:03 GMT
 - request:
     method: delete
-    uri: https://rspec-test-_9c837d:Ln%2AzYwnw%2AI5Lk8Ru@<%= extract_domain ENV["ONAPP_URI"]
-      %>/virtual_machines/mtcpy07758diww.json
+    uri: https://rspec-test-_5525c9:%25GkO%24%21SU2w%25OsqEx@<%= extract_domain ENV["ONAPP_URI"]
+      %>/virtual_machines/vdf9kraadsrk1b.json
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 204
       message: No Content
     headers:
       Date:
-      - Mon, 26 Oct 2015 17:17:45 GMT
+      - Mon, 14 Dec 2015 14:27:38 GMT
       Server:
       - Apache/2.2.15 (CentOS)
       X-Ua-Compatible:
@@ -389,15 +425,15 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 814934a8c10f59d181daf6947e4027b8
+      - df1fe2cf8d9ebfc975a039842aa35b00
       X-Runtime:
-      - '0.234840'
+      - '0.894684'
       X-Rack-Cache:
       - invalidate, pass
       X-Powered-By:
       - Phusion Passenger 4.0.35
       Set-Cookie:
-      - _session_id=37deb5d64d5c03ee105146e5fd14f8dd; path=/; HttpOnly
+      - _session_id=f467f3a4294b88b35ccedf4f2db54613; path=/; HttpOnly
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Status:
@@ -412,22 +448,30 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 17:17:31 GMT
+  recorded_at: Mon, 14 Dec 2015 14:27:04 GMT
 - request:
     method: delete
     uri: https://<%= ENV["ONAPP_USER"] %>:<%= CGI.escape ENV["ONAPP_PASS"] %>@<%=
-      extract_domain ENV["ONAPP_URI"] %>/users/403.json
+      extract_domain ENV["ONAPP_URI"] %>/users/560.json
     body:
       encoding: UTF-8
-      string: force=1
-    headers: {}
+      string: '{"force":1}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 204
       message: No Content
     headers:
       Date:
-      - Mon, 26 Oct 2015 17:17:45 GMT
+      - Mon, 14 Dec 2015 14:27:40 GMT
       Server:
       - Apache/2.2.15 (CentOS)
       X-Ua-Compatible:
@@ -435,15 +479,15 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - cfdde684dbb2c6ff38ba30c32a4cc8f4
+      - d35ecadd15b1d7e4bca285a163264907
       X-Runtime:
-      - '0.322249'
+      - '1.999162'
       X-Rack-Cache:
       - invalidate, pass
       X-Powered-By:
       - Phusion Passenger 4.0.35
       Set-Cookie:
-      - _session_id=f31a8ccecc2c43dce367432290444c81; path=/; HttpOnly
+      - _session_id=bf8578e13147efda17ba1df4ae1bafdd; path=/; HttpOnly
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Status:
@@ -458,5 +502,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 26 Oct 2015 17:17:32 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Mon, 14 Dec 2015 14:27:07 GMT
+recorded_with: VCR 3.0.0

--- a/spec/integration/assistant.rb
+++ b/spec/integration/assistant.rb
@@ -1,0 +1,108 @@
+require 'net/ssh'
+require 'integration/cloudnet_api'
+
+# Just a way to organise all the steps involved in running integration tests
+module IntegrationAssistant
+  include CloudnetAPI
+
+  def setup
+    @email = 'user@example.com'
+  end
+
+  def register
+    visit '/auth/register'
+    find(:css, '.fullname-input').set 'Mr. Person'
+    find(:css, '.email-input').set @email
+    find(:css, 'input[type=submit]').click
+    expect(page).to have_css('.form-feedback')
+    expect(find(:css, '.form-feedback')).to have_content('Thanks')
+  end
+
+  def goto_confirmation_page
+    email = Mail::TestMailer.deliveries.first
+    confirmation_link = email.body.parts.first.body.match(/href=[\'"]?([^\'" >]+)/)[0].gsub('href="', '')
+    visit confirmation_link
+  end
+
+  def confirm
+    goto_confirmation_page
+    find(:css, '.password-input').set 'password'
+    find(:css, '.passwordconfirm-input').set 'password'
+    find(:css, 'input[type=submit]').click
+    expect(page).to have_css('.form-feedback')
+    expect(find(:css, '.form-feedback')).to have_content('Your account has been confirmed')
+  end
+
+  def login
+    visit '/auth/login'
+    find(:css, '.email-input').set @email
+    find(:css, '.password-input').set 'password'
+    find(:css, 'input[type=submit]').click
+    expect(page).to have_content('Your Dashboard')
+  end
+
+  def note_api_key
+    @api_key = find(:css, '.keyvalues-api-key-value').text
+    @user = User.find_by email: @email
+    expect(@api_key).to eq @user.cloudnet_api_key
+  end
+
+  def create_server
+    expect do
+      params = { template: Template.find_an_ubuntu_template.id }
+      json = cloudnet_api_request(:post, '/servers', params)
+      @server = Server.find json['id']
+    end.to change { Server.count }.from(0).to(1)
+  end
+
+  def wait_for_server_to_boot
+    Timeout.timeout(Cloudnet::SERVER_BUILD_MAX_WAIT) do
+      loop do
+        @server.reload
+        break if @server.state == :on
+        sleep 1
+      end
+      # Then add a few more seconds grace
+      sleep 10
+    end
+  end
+
+  def request_server_credentials
+    json = cloudnet_api_request :get, "/servers/#{@server.id}"
+    expect(json['ip_address']).not_to be_empty
+    expect(json['initial_root_password']).not_to be_empty
+  end
+
+  def ssh_into_server
+    hostname = Net::SSH.start(*ssh_args) do |ssh|
+      ssh.exec!('hostname')
+    end.strip
+    expect(hostname).to eq @server.hostname
+  end
+
+  def ssh_args
+    [
+      @server.ip_address.strip,
+      'root',
+      {
+        password: @server.initial_root_password,
+        # Don't raise an error when there's a fingerprint mismatch
+        paranoid: Net::SSH::Verifiers::Null.new
+      }
+    ]
+  end
+
+  def delete_server
+    cloudnet_api_request :delete, "/servers/#{@server.id}"
+    expect do
+      cloudnet_api_request :get, "/servers/#{@server.id}"
+    end.to raise_error Faraday::Error::ResourceNotFound
+  end
+
+  def cleanup
+    # Cleanup the OnApp server because it won't get deleted if the integration tests fail half way through
+    Server.all.each(&:destroy_onapp_server)
+    # Cleanup the onapp user from the OnApp sandbox
+    OnappAPI.admin(:delete, "users/#{@user.id}", body: { force: 1 }) if @user
+  end
+end

--- a/spec/integration/cloudnet_api.rb
+++ b/spec/integration/cloudnet_api.rb
@@ -1,0 +1,30 @@
+# Make API requests to the cloud.net API as if we were an end-user
+module CloudnetAPI
+  private
+
+  def cloudnet_api_connection
+    host = Capybara.app_host.gsub('www', 'api')
+    port = Capybara.current_session.server.port
+    Faraday.new(url: "#{host}:#{port}", ssl: { verify: false }) do |faraday|
+      faraday.use Faraday::Response::RaiseError
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+
+  def cloudnet_api_request(verb, path, params = nil)
+    begin
+      response = make_faraday_request verb, path, params
+    rescue Faraday::ClientError => exception
+      raise exception, exception.response
+    end
+    JSON.parse response.body
+  end
+
+  def make_faraday_request(verb, path, params = nil)
+    cloudnet_api_connection.send(verb) do |request|
+      request.headers['Authorization'] = "APIKEY #{@api_key}"
+      request.url path
+      request.params = params if params
+    end
+  end
+end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -1,0 +1,75 @@
+# Here we are preparing for full, end-to-end integration tests that try to emulate the deployed production
+# environment as closely as possible. We boot up the API, frontend, transactions daemon and worker process.
+# Tests are run through a headless browser using phantomjs through the Capybara gem.
+
+# Build the frontend JS, CSS, etc
+print 'Building frontend ... '
+output = `npm run production 2>&1`
+puts output if $CHILD_STATUS.to_i > 0
+puts 'done.'
+
+ENV['RACK_ENV'] = 'test'
+# vcap.me is managed by Cloud Foundry, so it should be reliable. It, and all its ssubdomains point to 127.0.0.1
+ENV['CLOUDNET_DOMAIN'] = 'vcap.me'
+
+# Capybara is the thing that wraps a headless browser and lets you click on things inside Rspec tests.
+require 'capybara/poltergeist'
+require 'capybara/rspec'
+Capybara.default_max_wait_time = 15
+Capybara.default_driver = :poltergeist
+Capybara.app_host = 'http://www.vcap.me'
+# This is because Capybara's app_host setting assumes an external website and therefore assumes port 80, but we're
+# actually pointing to the local Capybara instance so we need to tell Capybara to include the port that it uses for
+# the test server.
+Capybara.always_include_port = true
+
+# There are pros and cons to using Sidekiq's inline mode.
+# Pros:
+#   * that we don't need to boot up the Sidekiq server as a separate process
+#   * we can stub out various parts of Sidekiq's code, namely the mailer
+# Cons:
+#   * Sidekiq's inline mode isn't how it works in production, so there could be subtle differences. The only one I can
+#     think of at the moment is that
+require 'sidekiq/testing'
+Sidekiq::Testing.inline!
+
+# Boot the application
+base_dir = File.join File.dirname(__FILE__), '/../..'
+require File.join base_dir, 'config/boot'
+Cloudnet.check_onapp_api_version!
+
+# Run the API server and frontend UI
+config_ru = File.read File.join base_dir, '/config.ru'
+# Clearly eval() is less than optimal, but it makes things so much easier in booting up the API server and the
+# frontend, whilst still allowing the app to be stubbed.
+Capybara.app = eval("Rack::Builder.new { #{config_ru} }") # rubocop:disable Lint/Eval
+
+# Boot the Transactions Daemon
+Thread.abort_on_exception = true
+Thread.new do
+  Transactions::Sync.run
+end
+
+# As little should be stubbed as possible in integration tests, but in order to retrieve links from emails, this is
+# really the easiest way.
+Mail.defaults do
+  delivery_method :test
+end
+
+RSpec.configure do |c|
+  c.mock_with :rspec
+  c.expect_with :rspec
+  c.color = true
+  c.include Capybara::DSL
+
+  c.before(:each) do
+    Sidekiq::Worker.clear_all
+    Mail::TestMailer.deliveries.clear
+    # Ensure the DB is clean before each spec
+    Mongoid.disconnect_clients
+    Mongoid::Clients.default.database.drop
+    print 'Updating Federation Resources ... '
+    UpdateFederationResources.run
+    puts 'done.'
+  end
+end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,0 +1,28 @@
+require 'integration/integration_helper'
+require 'integration/assistant'
+
+describe 'Registration' do
+  include IntegrationAssistant
+
+  before do
+    setup
+  end
+
+  after do
+    cleanup
+  end
+
+  # TODO: What about using proper it{} syntax for each stage? It would be possible if all the specs were ran in order
+  # and the DB wasn't cleaned in the before{} block.
+  it 'should allow a user to register, create a server, ssh into it and then destroy it' do
+    register
+    confirm
+    login
+    note_api_key
+    create_server
+    wait_for_server_to_boot
+    request_server_credentials
+    ssh_into_server
+    delete_server
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,11 @@
 ENV['RACK_ENV'] = 'test'
 
-# Stub values from ENV
-ENV['ONAPP_URI'] = 'https://localhost'
-ENV['ONAPP_USER'] = 'test'
-ENV['ONAPP_PASS'] = 'test'
-ENV['ONAPP_CLOUDNET_ROLE'] = '2'
-
-require 'coveralls'
-Coveralls.wear_merged!
+require 'simplecov'
+require 'simplecov-lcov'
+SimpleCov.coverage_dir 'coverage/ruby'
+SimpleCov::Formatter::LcovFormatter.report_with_single_file = true
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+SimpleCov.start
 
 require File.expand_path('../../config/boot', __FILE__) unless ENV['ADMIN_TESTS'] == 'true'
 

--- a/spec/specs/models/server_spec.rb
+++ b/spec/specs/models/server_spec.rb
@@ -9,6 +9,9 @@ describe Server do
       @user = User.find_by user_details[:email]
 
       UpdateFederationResources.run
+
+      # Unless the password is the same every time then VCR can't match HTTP requests against a cassette
+      allow(System).to receive(:generate_onapp_password).and_return('ABC123abc!%$')
     end
 
     after :each do


### PR DESCRIPTION
End to end integration tests using Capybara.

I'm wondering if there is a better way to run specs like this where a series of tests needs to be run in order? I'm thinking it's more useful to use individual `it{}` blocks that are run in order and do not get a DB clean in `before{}`. Of course the DB would cleaned in `before(:suite){}`.